### PR TITLE
Added cri-dockerd's go version detection script

### DIFF
--- a/k8s-cluster-bootstrap.sh
+++ b/k8s-cluster-bootstrap.sh
@@ -411,25 +411,27 @@ else
   usermod -aG docker $USER
   printstyle 'Success! \n \n' 'success'
 
+  # clone the repository
+  lineprint
+  printstyle "Cloning cri-dockerd repository ... \n" 'info'
+  lineprint
+  git clone https://github.com/Mirantis/cri-dockerd.git
+  printstyle 'Success! \n \n' 'success'
+
+  go_version=$(grep "^go " cri-dockerd/go.mod | cut -d ' ' -f 2)
+
   # Installing go lang
   lineprint
   printstyle "Installing Golang ... \n" 'info'
   lineprint
-  wget https://go.dev/dl/go1.20.5.linux-amd64.tar.gz
-  rm -rf /usr/local/go && tar -C /usr/local -xzf go1.20.5.linux-amd64.tar.gz
+  wget https://go.dev/dl/go${go_version}.linux-amd64.tar.gz
+  rm -rf /usr/local/go && tar -C /usr/local -xzf go${go_version}.linux-amd64.tar.gz
   echo 'export PATH=$PATH:/usr/local/go/bin' >>${HOME_PATH}/.profile
   echo 'export GOPATH=$HOME/go' >>${HOME_PATH}/.profile
   source ${HOME_PATH}/.profile
   mkdir -p $GOPATH
   go version
   sleep 3
-  printstyle 'Success! \n \n' 'success'
-
-  # clone the repository
-  lineprint
-  printstyle "Cloning cri-dockerd repository ... \n" 'info'
-  lineprint
-  git clone https://github.com/Mirantis/cri-dockerd.git
   printstyle 'Success! \n \n' 'success'
 
   # Install Container runtime (cri-dockerd)


### PR DESCRIPTION
## Proposed changes

This pull request introduces a hotfix to the Kubernetes bootstrap script to ensure compatibility with the cri-dockerd component. Previously, the Go version used in the bootstrap script was hardcoded, which could lead to version mismatches with cri-dockerd's requirements. The proposed change detects the Go version required by cri-dockerd automatically and installs the appropriate version of Go. This update ensures seamless compatibility and prevents potential runtime errors caused by Go version incompatibility.

## Types of changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have pushed my branch to develop branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

This change was necessary due to the frequent updates in the Go language and the specific requirements of cri-dockerd. By implementing an automatic detection mechanism for the required Go version, we mitigate the risk of version-related issues and ensure smoother deployments. Alternatives considered included manually updating the Go version in the script with each release of cri-dockerd, but this approach was deemed less efficient and prone to errors.